### PR TITLE
Use new @googlemaps/google-maps-services-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,40 +10,27 @@ yarn add feathers-google-maps
 
 ## Documentation
 
-This service is a light wrapper around the @google/maps library. Please refer to the [@google/maps](https://github.com/googlemaps/google-maps-services-js) documenation for options that can be passed. You will also find it helpful to reference the [Google Maps Web Service APIs](https://developers.google.com/maps/apis-by-platform#web_service_apis) docs.
-
-This service not only allows the power of feathers hooks, events, etc, but it
-also solves some common problems and shortcomings of @google/maps such as:
-
-- Async by default. There is no need to pass the `Promise` option. It is provided by default but can be overriden by a different promise contructor. feathers-google-maps does not support callbacks.
-
-- Catches the string errors thrown. @google/maps will sometimes throw string errors. For example, `throw 'timeout'`. These errors, and all others, are wrapped in [@feathersjs/errors](https://docs.feathersjs.com/api/errors.html)
-
-- Catches sync errors. @google/maps will also throw sync errors where you would expect a standard `.catch()` to handle the error but is never reached. These are wrapped in a try/catch and handled asyncronously.
+This service is a light wrapper around the @googlemaps/google-maps-services-js library. Please refer to the [@googlemaps/google-maps-services-js](https://github.com/googlemaps/google-maps-services-js) documenation for options that can be passed. You will also find it helpful to reference the [Google Maps Web Service APIs](https://developers.google.com/maps/apis-by-platform#web_service_apis) docs.
 
 ### Available Services
 
 The following methods are supported and map to the appropriate @google/maps methods:
 
 - directions
-- distanceMatrix
+- distancematrix
 - elevation
-- elevationAlongPath
 - geocode
-- geolocate
 - reverseGeocode
-- findPlace
-- places
+- geolocate
+- placeAutocomplete
+- placeDetails
+- findPlaceFromText
+- placePhoto
 - placesNearby
-- placesRadar
-- place
-- placesPhoto
-- placesAutoComplete
-- placesQueryAutoComplete
-- snapToRoads
+- placeQueryAutocomplete
+- textSearch
 - nearestRoads
-- speedLimits
-- snappedSpeedLimits
+- snapToRoads
 - timezone
 
 ## Creating a Service
@@ -61,7 +48,7 @@ app.use('directions', Directions);
 
 The service exposes two methods, `find(params)` and `create(data, params)`. These two methods are functionally equivalent. The `create()` method is added so that you can take advantage of the `.on('created')` service event.
 
-When using the `find(params)` method, include the `query` as the query to be passed to the underlying method.
+When using the `find(params)` method, include the `query` as the params to be passed to the underlying GoogleMaps method.
 
 ```js
 app.service('directions').find({
@@ -70,19 +57,34 @@ app.service('directions').find({
     destination: 'Memphis, TN'
   }
 });
+
+// This will call the googlMaps method like
+googleMaps.directions({
+  params: {
+    origin: 'Nashville, TN',
+    destination: 'Memphis, TN',
+    key: 'YOUR API KEY'
+  }
+});
 ```
 
-When using the `create(data, params)` method, the `data` will be passed to the underlying method.
+When using the `create(data, params)` method, the `data` will be passed to the underlying GoogleMaps method.
 
 ```js
 app.service('directions').create({
   origin: 'Nashville, TN',
   destination: 'Memphis, TN'
 });
-```
 
-@google/maps also allows you to pass custom parameters to method calls. These can be passed by adding `params.googleMaps`.
-On successful calls, the raw response will be added to `params.googleMaps.response` to be accessed in your `after` hooks. On calls that threw an error, the raw error will be added to `params.googleMaps.error` to be accessed in your `error` hooks.
+// This will also call the googlMaps method like
+googleMaps.directions({
+  params: {
+    origin: 'Nashville, TN',
+    destination: 'Memphis, TN',
+    key: 'YOUR API KEY'
+  }
+});
+```
 
 ## Complete Example
 

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,21 +1,26 @@
-const { GeneralError, Timeout, BadRequest } = require('@feathersjs/errors');
+const feathersErrors = require('@feathersjs/errors');
 
 module.exports = function errorHandler(error, params) {
 
   Object.assign(params, { googleMaps: { ...params.googleMaps, error } });
 
-  let feathersError = error;
+  const { response } = error;
 
-  // Google maps sometimes throws string errors
-  switch (error) {
-    case 'timeout':
-      feathersError = new Timeout('Google Maps timed out', error);
-      break;
-    case 'Missing either a valid API key, or a client ID and secret':
-      feathersError = new GeneralError(error, error);
-      break;
-    default:
-      feathersError = new BadRequest(error);
+  let feathersError;
+
+  if (response.status && feathersErrors[response.status]) {
+    feathersError = new feathersErrors[response.status](
+      response.data && response.data.error_message || error.message,
+      response.data
+    );
+  } else {
+    feathersError = new feathersErrors.FeathersError(
+      response.data && response.data.error_message || error.message,
+      response.data && response.data.status,
+      response.status,
+      response.data && response.data.status,
+      response.data
+    );
   }
 
   return Promise.reject(feathersError);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,45 +1,38 @@
-const googleMaps = require('@google/maps');
+// const googleMaps = require('@google/maps');
+const googleMaps = require('@googlemaps/google-maps-services-js');
+const { GeneralError } = require('@feathersjs/errors');
 const errorHandler = require('./error-handler');
 const successHandler = require('./success-handler');
 
+
 module.exports = class GoogleMapsService {
-  constructor (_options) {
+  constructor (opts) {
+    this.options = { ...opts };
+    this.googleMaps = new googleMaps.Client({});
+  }
 
-    const { method, ...rest } = _options;
-
-    this.googleMaps = googleMaps.createClient({ Promise: Promise, ...rest });
-
-    const methods = Object.keys(this.googleMaps);
-
-    if (!method || !methods.includes(method)) {
-      throw new Error(
-        `"${method}" is not a valid Google Maps method. Must be one of: ${methods.map(method => ' ' + method)}`
-      );
+  method(googleParams, feathersParams) {
+    const { method, key } = this.options;
+    const googleKey = key || googleParams.key;
+    if (!googleKey) {
+      throw new GeneralError('You must use an API key to authenticate each request to Google Maps Platform APIs. For additional information, please refer to http://g.co/dev/maps-no-account');
     }
-
-    this.method = (query, params) => {
-      // Google maps client throws errors synchronously sometimes...
-      // For example, an invalid query will not trip the .catch()
-      // promise method but will instead throw synchronously.
-      try {
-        const customParams = params.googleMaps || {};
-        return this.googleMaps[method](query, undefined, customParams)
-          .asPromise()
-          .then(response => successHandler(response, params))
-          .catch(error => errorHandler(error, params));
-      } catch (error) {
-        return errorHandler(error, params)
+    return this.googleMaps[method]({
+      params: {
+        key: googleKey,
+        ...googleParams
       }
-    };
+    })
+      .then(response => successHandler(response, feathersParams))
+      .catch(error => errorHandler(error, feathersParams));
+  };
 
+  find(feathersParams) {
+    return this.method(feathersParams.query, feathersParams);
   }
 
-  find(params) {
-    return this.method(params.query, params);
-  }
-
-  create(data, params) {
-    return this.method(data, params);
+  create(data, feathersParams) {
+    return this.method(data, feathersParams);
   }
 
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,38 +1,46 @@
-// const googleMaps = require('@google/maps');
-const googleMaps = require('@googlemaps/google-maps-services-js');
+const googleMapsService = require('@googlemaps/google-maps-services-js');
 const { GeneralError } = require('@feathersjs/errors');
 const errorHandler = require('./error-handler');
 const successHandler = require('./success-handler');
 
 
 module.exports = class GoogleMapsService {
-  constructor (opts) {
-    this.options = { ...opts };
-    this.googleMaps = new googleMaps.Client({});
+  constructor (options) {
+    const { method, key, ...googleConfig } = options;
+    this.googleKey = key;
+    this.googleMethod = method;
+    this.googleMapsService = new googleMapsService.Client(googleConfig);
   }
 
-  method(googleParams, feathersParams) {
-    const { method, key } = this.options;
-    const googleKey = key || googleParams.key;
+  method(googleParams, feathersParams = {}) {
+    const { googleMaps: googleOptions } = feathersParams;
+
+    const googleKey = googleParams.key
+      || googleOptions && googleOptions.key
+      || this.googleKey
+
     if (!googleKey) {
       throw new GeneralError('You must use an API key to authenticate each request to Google Maps Platform APIs. For additional information, please refer to http://g.co/dev/maps-no-account');
     }
-    return this.googleMaps[method]({
+
+    return this.googleMapsService[this.googleMethod]({
       params: {
         key: googleKey,
         ...googleParams
-      }
+      },
+      ...googleOptions
     })
       .then(response => successHandler(response, feathersParams))
       .catch(error => errorHandler(error, feathersParams));
   };
 
-  find(feathersParams) {
-    return this.method(feathersParams.query, feathersParams);
+  find(params) {
+    const { query: googleParams, ...feathersParams } = params;
+    return this.method(googleParams, feathersParams);
   }
 
-  create(data, feathersParams) {
-    return this.method(data, feathersParams);
+  create(googleParams, feathersParams) {
+    return this.method(googleParams, feathersParams);
   }
 
 };

--- a/lib/success-handler.js
+++ b/lib/success-handler.js
@@ -2,5 +2,5 @@ module.exports = function successHandler(response, params) {
 
   Object.assign(params, { googleMaps: { ...params.googleMaps, response } });
 
-  return Promise.resolve(response.json);
+  return Promise.resolve(response.data);
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "feathers-google-maps",
   "version": "0.0.1",
   "description": "A Feathers service for interacting with the Google Maps API",
-  "keywords": ["feathers", "google maps"],
+  "keywords": [
+    "feathers",
+    "google maps"
+  ],
   "main": "lib/",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -19,6 +22,6 @@
   "homepage": "https://github.com/DaddyWarbucks/feathers-google-maps#readme",
   "dependencies": {
     "@feathersjs/errors": "^4.3.0",
-    "@google/maps": "^0.5.5"
+    "@googlemaps/google-maps-services-js": "^2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   ],
   "main": "lib/",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "release:patch": "npm version patch && npm publish",
+    "release:minor": "npm version minor && npm publish",
+    "release:major": "npm version major && npm publish"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/DaddyWarbucks/feathers-google-maps#readme",
   "dependencies": {
     "@feathersjs/errors": "^4.3.0",
-    "@googlemaps/google-maps-services-js": "^2.0.2"
+    "@googlemaps/google-maps-services-js": "^3.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,26 +9,93 @@
   dependencies:
     debug "^4.1.1"
 
-"@google/maps@^0.5.5":
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/@google/maps/-/maps-0.5.5.tgz#478a5791e3b8d444be966462daec3ee43eb331e0"
-  integrity sha512-RSZriyE2XViVhXgdEcQaEu3jMYh2A/jS0VahLHXqGO0VfPyEbDac4PAn7/hBJiTavWpxchKfe5OI9inJofFWxA==
+"@googlemaps/google-maps-services-js@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@googlemaps/google-maps-services-js/-/google-maps-services-js-2.0.2.tgz#cb056d54208ab5e38a867f8310b8b6562112c14e"
+  integrity sha512-AzhUckl3X9QmopPxx/QKUwoUenvnkhTAP6811siaociclxS3vf4GHGVIMAEHVcvjt+2cWeq+603gLBVciS5TKg==
   dependencies:
-    uuid ">=2.2.1"
+    agentkeepalive "^4.1.0"
+    axios "^0.19.0"
+    query-string "github:jpoehnelt/query-string#e22cdb49ef848efaed4fe60d63d2504b496027c1"
 
-debug@^4.1.1:
+agentkeepalive@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.1.0.tgz#a48e040ed16745dd29ce923675f60c9c90f39ee0"
+  integrity sha512-CW/n1wxF8RpEuuiq6Vbn9S8m0VSYDMnZESqaJ6F2cWN9fY8rei2qaxweIaRgq+ek8TqfoFIsUjaGNKGGEHElSg==
+  dependencies:
+    debug "^4.1.0"
+    depd "^1.1.2"
+    humanize-ms "^1.2.1"
+
+axios@^0.19.0:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
+debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
-ms@^2.1.1:
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+depd@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+  dependencies:
+    ms "^2.0.0"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-uuid@>=2.2.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
-  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
+"query-string@github:jpoehnelt/query-string#e22cdb49ef848efaed4fe60d63d2504b496027c1":
+  version "6.9.0"
+  resolved "https://codeload.github.com/jpoehnelt/query-string/tar.gz/e22cdb49ef848efaed4fe60d63d2504b496027c1"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,14 +9,15 @@
   dependencies:
     debug "^4.1.1"
 
-"@googlemaps/google-maps-services-js@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@googlemaps/google-maps-services-js/-/google-maps-services-js-2.0.2.tgz#cb056d54208ab5e38a867f8310b8b6562112c14e"
-  integrity sha512-AzhUckl3X9QmopPxx/QKUwoUenvnkhTAP6811siaociclxS3vf4GHGVIMAEHVcvjt+2cWeq+603gLBVciS5TKg==
+"@googlemaps/google-maps-services-js@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@googlemaps/google-maps-services-js/-/google-maps-services-js-3.1.2.tgz#6d5edf816f3a9c165e828cea34bf7959a7aedfae"
+  integrity sha512-RmCyqs9L0KiqTHmmx31NLwtZ3dqjX1w/zD/NuHHah+gCVEj427ZuyVFxgcXUm38ttUukpBLtLlxT036JYek1jA==
   dependencies:
     agentkeepalive "^4.1.0"
     axios "^0.19.0"
-    query-string "github:jpoehnelt/query-string#e22cdb49ef848efaed4fe60d63d2504b496027c1"
+    query-string "^6.11.0"
+    retry-axios "^2.2.1"
 
 agentkeepalive@^4.1.0:
   version "4.1.0"
@@ -82,13 +83,19 @@ ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-"query-string@github:jpoehnelt/query-string#e22cdb49ef848efaed4fe60d63d2504b496027c1":
-  version "6.9.0"
-  resolved "https://codeload.github.com/jpoehnelt/query-string/tar.gz/e22cdb49ef848efaed4fe60d63d2504b496027c1"
+query-string@^6.11.0:
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.1.tgz#d913ccfce3b4b3a713989fe6d39466d92e71ccad"
+  integrity sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==
   dependencies:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
+
+retry-axios@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-2.2.1.tgz#da3cb93436fa2f931332d4e6a9927bd6cfa618c8"
+  integrity sha512-vSZzu29W48+/mVPOq+gwKe+qYWcppiKODXi4FN9q0iN+4s2z10/l1LDS4Ju4vReTyuvKOoqmHqY0rOAmuFjI/Q==
 
 split-on-first@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
The underlying `@google/maps` library has always been tedious and poorly written. There has finally been an official update of this lib at `@googlemaps/google-maps-services-js`. This PR is a first pass at implementing this new library.

This will be a major version bump as not all method names are the same as the old lib. This is also not complete and just a first pass and needs more attention, but it is generally working.